### PR TITLE
Fix link to SF-450 section

### DIFF
--- a/checklists/newHire.json
+++ b/checklists/newHire.json
@@ -177,7 +177,7 @@
 	},
 	"fillOutForm": { 
 		"displayName": "Fill out SF-450", 
-		"description": "<a href=\"https://handbook.18f.gov/hatch-act-foia-ethics-code-of-conduct/#heading-2\">Instructions</a>",
+		"description": "<a href=\"https://handbook.18f.gov/hatch-act-foia-ethics-code-of-conduct/#a-iddocumentationdocumentationa\">Instructions</a>",
 		"daysToComplete": 20, 
 		"dependsOn": ["dayZero"]
 	},


### PR DESCRIPTION
Previous anchor (`#heading-2`) does not exist on the https://handbook.18f.gov/hatch-act-foia-ethics-code-of-conduct/ page