### PR TITLE
Use node 5.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - 0.12
+    - 5.10.0
 before_script:
     - "npm i -g jasmine-node"
     - "sleep 5"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express-session": "^1.11.3",
     "github": "^0.2.4",
     "istanbul": "^0.4.1",
+    "jasmine-core": "^2.4.1",
     "jasmine-node": "^1.14.5",
     "karma": "~0.12",
     "karma-chrome-launcher": "^0.1.12",
@@ -39,8 +40,8 @@
     "coveralls": "cat ./coverage/lcov.info ./coverage/phantomjs/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "engines": {
-    "node": "^4.4.2",
-    "npm": "2.14.4"
+    "node": "^5.10.0",
+    "npm": "^3.8.3"
   },
   "author": "Anthony Garvan",
   "license": "CC0"


### PR DESCRIPTION
Ref #59 

Node 5.10.0 is supported by both Travis and the current cloud.gov Node buildpack. This can supercede #63 while we wait for v6.10.0 support.

@anthonygarvan thoughts?