### PR TITLE
move testing packages to devDependencies, closes #60

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,20 @@
     "async": "^1.5.2",
     "body-parser": "^1.14.1",
     "bower": "^1.7.2",
-    "coveralls": "^2.11.6",
     "express": ">= 0.0.0",
     "express-session": "^1.11.3",
     "github": "^0.2.4",
+    "method-override": "^2.3.5",
+    "mkdirp": "^0.5.1",
+    "mongodb": "^2.1.2",
+    "passport": "^0.3.2",
+    "passport-github2": "^0.1.9",
+    "phantomjs": "^1.9.19",
+    "request": "^2.67.0",
+    "router": "^1.1.3"
+  },
+  "devDependencies": {
+    "coveralls": "^2.11.6",
     "istanbul": "^0.4.1",
     "jasmine-core": "^2.4.1",
     "jasmine-node": "^1.14.5",
@@ -20,15 +30,7 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.3.5",
     "karma-junit-reporter": "^0.2.2",
-    "karma-phantomjs-launcher": "^0.2.3",
-    "method-override": "^2.3.5",
-    "mkdirp": "^0.5.1",
-    "mongodb": "^2.1.2",
-    "passport": "^0.3.2",
-    "passport-github2": "^0.1.9",
-    "phantomjs": "^1.9.19",
-    "request": "^2.67.0",
-    "router": "^1.1.3"
+    "karma-phantomjs-launcher": "^0.2.3"
   },
   "scripts": {
     "postinstall": "bower install",


### PR DESCRIPTION
This should speed up deployments very slightly since fewer packages will need to be installed. Might not even be noticeable though.