### PR TITLE
use mockery during backend testing

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,113 +10,107 @@ var GitHubStrategy = require('passport-github2').Strategy;
 var api = require('./api/api.js');
 var github = require('./api/github.js').github;
 
-var serverApp;
 var server;
+var app = express();
 
-var getApp = function (passport, GitHubStrategy, github) { // eslint-disable-line no-shadow
-  var app = express();
-  api.setGithub(github);
+api.setGithub(github);
 
-  passport.serializeUser(function (user, done) {
-    done(null, user);
+passport.serializeUser(function (user, done) {
+  done(null, user);
+});
+
+passport.deserializeUser(function (obj, done) {
+  done(null, obj);
+});
+
+passport.use(new GitHubStrategy({
+  clientID: process.env.GITHUB_CLIENT_ID,
+  clientSecret: process.env.GITHUB_CLIENT_SECRET,
+  callbackURL: process.env.GITHUB_CALLBACK_URL || 'http://localhost:3000/auth/callback'
+}, function (accessToken, refreshToken, profile, done) {
+  process.nextTick(function () {
+    return done(null, profile);
   });
+}));
 
-  passport.deserializeUser(function (obj, done) {
-    done(null, obj);
-  });
-
-  passport.use(new GitHubStrategy({
-    clientID: process.env.GITHUB_CLIENT_ID,
-    clientSecret: process.env.GITHUB_CLIENT_SECRET,
-    callbackURL: process.env.GITHUB_CALLBACK_URL || 'http://localhost:3000/auth/callback'
-  }, function (accessToken, refreshToken, profile, done) {
-    process.nextTick(function () {
-      return done(null, profile);
-    });
-  }));
-
-  function ensureAuthenticated(req, res, next) {
-    if (req.isAuthenticated()) {
-      next();
-      return;
-    }
-    res.redirect('/auth');
+function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated()) {
+    next();
+    return;
   }
+  res.redirect('/auth');
+}
 
-  function ensureGithubOrg(req, res, next) {
-    api.db.collection('users').findOne({ username: req.user.username },
-      function (err, user) {
-        if (user) {
-          next();
-        } else {
-          github.orgs.getFromUser({ user: req.user.username },
-            function (getFromUserErr, orgs) {
-              var inOrg = false;
-              orgs.forEach(function (org) {
-                if (org.login === process.env.GITHUB_ORG) {
-                  inOrg = true;
-                }
-              });
-              if (inOrg) {
-                next();
-              } else {
-                res.redirect('/not-authorized.html');
+function ensureGithubOrg(req, res, next) {
+  api.db.collection('users').findOne({ username: req.user.username },
+    function (err, user) {
+      if (user) {
+        next();
+      } else {
+        github.orgs.getFromUser({ user: req.user.username },
+          function (getFromUserErr, orgs) {
+            var inOrg = false;
+            orgs.forEach(function (org) {
+              if (org.login === process.env.GITHUB_ORG) {
+                inOrg = true;
               }
             });
-        }
-      });
-  }
-
-  function addToUsers(req, res, next) {
-    api.db.collection('users').findOne({ username: req.user.username },
-      function (err, user) {
-        var newUser;
-        if (!user) {
-          newUser = {
-            username: req.user.username,
-            earliestDueDate: new Date().setYear(3000),
-            fullName: req.user._json.name,
-            imgUrl: req.user._json.avatar_url
-          };
-          api.db.collection('users').insert(newUser);
-        }
-        next();
-      });
-  }
-
-  app.use(bodyParser());
-  app.use(bodyParser.json());
-  app.use(methodOverride());
-  app.use(session({ secret: process.env.SESSION_SECRET }));
-  app.use(passport.initialize());
-  app.use(passport.session());
-
-  app.use('/private', [ensureAuthenticated, ensureGithubOrg,
-    addToUsers, express.static('private')]);
-  app.use('/api', [ensureAuthenticated, ensureGithubOrg, addToUsers, api.router]);
-
-  app.use('/', express.static('public'));
-
-  app.get('/auth', passport.authenticate('github', { scope: ['user:email'] }), function () {});
-
-  app.get('/auth/callback',
-    passport.authenticate('github', { failureRedirect: '/login' }),
-    function (req, res) {
-      res.redirect('/private/index.html');
+            if (inOrg) {
+              next();
+            } else {
+              res.redirect('/not-authorized.html');
+            }
+          });
+      }
     });
+}
 
-  app.get('/logout', function (req, res) {
-    req.logout();
-    res.redirect('/');
+function addToUsers(req, res, next) {
+  api.db.collection('users').findOne({ username: req.user.username },
+    function (err, user) {
+      var newUser;
+      if (!user) {
+        newUser = {
+          username: req.user.username,
+          earliestDueDate: new Date().setYear(3000),
+          fullName: req.user._json.name,
+          imgUrl: req.user._json.avatar_url
+        };
+        api.db.collection('users').insert(newUser);
+      }
+      next();
+    });
+}
+
+app.use(bodyParser());
+app.use(bodyParser.json());
+app.use(methodOverride());
+app.use(session({ secret: process.env.SESSION_SECRET }));
+app.use(passport.initialize());
+app.use(passport.session());
+
+app.use('/private', [ensureAuthenticated, ensureGithubOrg,
+  addToUsers, express.static('private')]);
+app.use('/api', [ensureAuthenticated, ensureGithubOrg, addToUsers, api.router]);
+
+app.use('/', express.static('public'));
+
+app.get('/auth', passport.authenticate('github', { scope: ['user:email'] }), function () {});
+
+app.get('/auth/callback',
+  passport.authenticate('github', { failureRedirect: '/login' }),
+  function (req, res) {
+    res.redirect('/private/index.html');
   });
 
-  return app;
-};
+app.get('/logout', function (req, res) {
+  req.logout();
+  res.redirect('/');
+});
 
-module.exports.getApp = getApp;
+module.exports = app;
 
 if (require.main === module) {
-  serverApp = getApp(passport, GitHubStrategy, github);
-  server = http.createServer(serverApp);
+  server = http.createServer(app);
   server.listen(process.env.PORT || 3000, function () {});
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "karma-jasmine": "^0.3.5",
     "karma-junit-reporter": "^0.2.2",
     "karma-phantomjs-launcher": "^0.2.3",
+    "mockery": "^1.7.0",
     "phantomjs": "^1.9.19"
   },
   "scripts": {


### PR DESCRIPTION
This simplifies app.js by removing the `getApp` function. Instead of passing in mock objects during testing, we instead use mockery to hook into node's require system, replacing instances of some modules with local mocks.

@anthonygarvan - thoughts?