### PR TITLE
Preview checklist

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "karma-junit-reporter": "^0.2.2",
     "karma-phantomjs-launcher": "^0.2.3",
     "mockery": "^1.7.0",
+    "nodemon": "^1.9.2",
     "phantomjs": "^1.9.19",
     "sinon": "^1.17.4",
     "supertest": "^1.2.0"
@@ -49,6 +50,7 @@
     "frontEndTests": "node node_modules/.bin/karma start karma.conf.js --no-auto-watch --single-run",
     "test": "npm run backEndTests && npm run frontEndTests",
     "start": "node app.js",
+    "dev-start": "nodemon app.js",
     "coverage": "istanbul cover node_modules/jasmine-node/bin/jasmine-node spec/backend",
     "coveralls": "cat ./coverage/lcov.info ./coverage/phantomjs/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },

--- a/private/js/app.js
+++ b/private/js/app.js
@@ -266,7 +266,7 @@ app.controller('PreviewChecklistController',
       $mdDialog.cancel();
     };
 
-    $scope.assign = function () {
+    $scope.showAssignToMeDialog = function () {
       $mdDialog.cancel();
       showAssignToMeDialog(null, checklist);
     };

--- a/private/js/app.js
+++ b/private/js/app.js
@@ -176,7 +176,7 @@ app.controller('todoCtrl', function ($scope, $http, $sce, $mdToast, $mdDialog, $
       });
   };
 
-  $scope.showPreview = function (ev, checklist) {
+  $scope.showPreviewDialog = function (ev, checklist) {
     var useFullScreen = ($mdMedia('sm') || $mdMedia('xs')) && $scope.customFullscreen;
     $mdDialog.show({
       controller: 'PreviewChecklistController',

--- a/private/js/app.js
+++ b/private/js/app.js
@@ -52,8 +52,8 @@ app.controller('todoCtrl', function ($scope, $http, $sce, $mdToast, $mdDialog, $
       }
     });
 
-    checklist.items = compiledItems;
-    return checklist;
+    checklistCopy.items = compiledItems;
+    return checklistCopy;
   };
 
   var showSimpleToast = function (msg) {
@@ -176,6 +176,19 @@ app.controller('todoCtrl', function ($scope, $http, $sce, $mdToast, $mdDialog, $
       });
   };
 
+  $scope.showPreview = function (ev, checklist) {
+    var useFullScreen = ($mdMedia('sm') || $mdMedia('xs')) && $scope.customFullscreen;
+    $mdDialog.show({
+      controller: 'PreviewChecklistController',
+      templateUrl: 'tmpl/preview.tmpl.html',
+      parent: angular.element(document.body),
+      targetEvent: ev,
+      clickOutsideToClose: true,
+      fullscreen: useFullScreen,
+      locals: { checklist: checklist }
+    });
+  };
+
   $scope.showAssignToMeDialog = function (ev, checklist) {
     var useFullScreen = ($mdMedia('sm') || $mdMedia('xs')) && $scope.customFullscreen;
     $mdDialog.show({
@@ -232,6 +245,24 @@ app.controller('AssignDialogController', function ($scope, $mdDialog, checklist)
   };
   $scope.assign = function () {
     $mdDialog.hide(checklist);
+  };
+});
+
+app.controller('PreviewChecklistController', function ($scope, $mdDialog, checklist) {
+  $scope.checklist = checklist;
+
+  $scope.sortedItems = Object.keys(checklist.items)
+    .map(function (key) { return checklist.items[key]; })
+    .sort(function (a, b) {
+      return a.daysToComplete - b.daysToComplete;
+    });
+
+  $scope.close = function () {
+    $mdDialog.cancel();
+  };
+
+  $scope.assign = function () {
+    alert('show alert dialog');
   };
 });
 

--- a/private/js/app.js
+++ b/private/js/app.js
@@ -185,7 +185,10 @@ app.controller('todoCtrl', function ($scope, $http, $sce, $mdToast, $mdDialog, $
       targetEvent: ev,
       clickOutsideToClose: true,
       fullscreen: useFullScreen,
-      locals: { checklist: checklist }
+      locals: {
+        checklist: checklist,
+        showAssignToMeDialog: $scope.showAssignToMeDialog
+      }
     });
   };
 
@@ -248,23 +251,27 @@ app.controller('AssignDialogController', function ($scope, $mdDialog, checklist)
   };
 });
 
-app.controller('PreviewChecklistController', function ($scope, $mdDialog, checklist) {
-  $scope.checklist = checklist;
+app.controller('PreviewChecklistController',
+  function ($scope, $mdDialog, checklist, showAssignToMeDialog) {
+    $scope.checklist = checklist;
 
-  $scope.sortedItems = Object.keys(checklist.items)
-    .map(function (key) { return checklist.items[key]; })
-    .sort(function (a, b) {
-      return a.daysToComplete - b.daysToComplete;
-    });
+    $scope.sortedItems = Object.keys(checklist.items)
+      .filter(function (key) { return key !== 'dayZero'; })
+      .map(function (key) { return checklist.items[key]; })
+      .sort(function (a, b) {
+        return a.daysToComplete - b.daysToComplete;
+      });
 
-  $scope.close = function () {
-    $mdDialog.cancel();
-  };
+    $scope.close = function () {
+      $mdDialog.cancel();
+    };
 
-  $scope.assign = function () {
-    alert('show alert dialog');
-  };
-});
+    $scope.assign = function () {
+      $mdDialog.cancel();
+      showAssignToMeDialog(null, checklist);
+    };
+  }
+);
 
 app.controller('AddUserDialogController', function ($scope, $mdDialog, $http) {
   $scope.cancel = function () {

--- a/private/tmpl/checklists.tmpl.html
+++ b/private/tmpl/checklists.tmpl.html
@@ -10,6 +10,7 @@
           </md-card-title-text>
         </md-card-title>
         <md-card-actions layout="row" layout-align="end center">
+          <md-button ng-click="showPreview($event, checklist)">Preview</md-button>
           <md-button ng-click="showAssignToMeDialog($event, checklist)">Assign To Me</md-button>
         </md-card-actions>
       </md-card>

--- a/private/tmpl/checklists.tmpl.html
+++ b/private/tmpl/checklists.tmpl.html
@@ -1,8 +1,8 @@
 
   <md-content class="md-padding">
     <div class="md-display-1">Checklists</div>
-    <div layout="row" layout-wrap layout-align="center">
-      <md-card ng-repeat="checklist in checklists" flex="45">
+    <div layout="row" layout-wrap layout-align="center" layout-xs="column">
+      <md-card ng-repeat="checklist in checklists" flex="45" flex-xs="90">
         <md-card-title>
           <md-card-title-text>
             <span class="md-headline">{{ checklist.checklistName }}</span>

--- a/private/tmpl/checklists.tmpl.html
+++ b/private/tmpl/checklists.tmpl.html
@@ -10,7 +10,7 @@
           </md-card-title-text>
         </md-card-title>
         <md-card-actions layout="row" layout-align="end center">
-          <md-button ng-click="showPreview($event, checklist)">Preview</md-button>
+          <md-button ng-click="showPreviewDialog($event, checklist)">Preview</md-button>
           <md-button ng-click="showAssignToMeDialog($event, checklist)">Assign To Me</md-button>
         </md-card-actions>
       </md-card>

--- a/private/tmpl/preview.tmpl.html
+++ b/private/tmpl/preview.tmpl.html
@@ -10,7 +10,7 @@
         <p>Tasks in Checklist "{{ checklist.checklistName }}"</p>
         <ul>
           <li ng-repeat="item in sortedItems">
-            {{ item.displayName }}
+            {{ item.displayName || item.prompt }}
           </li>
         </ul>
       </div>

--- a/private/tmpl/preview.tmpl.html
+++ b/private/tmpl/preview.tmpl.html
@@ -6,12 +6,14 @@
       </div>
     </md-toolbar>
     <md-dialog-content>
-      <p>Preview Checklist "{{ checklist.checklistName }}"</p>
-      <ul>
-        <li ng-repeat="item in sortedItems">
-          {{ item.displayName }}
-        </li>
-      </ul>
+      <div class="md-dialog-content">
+        <p>Tasks in Checklist "{{ checklist.checklistName }}"</p>
+        <ul>
+          <li ng-repeat="item in sortedItems">
+            {{ item.displayName }}
+          </li>
+        </ul>
+      </div>
     </md-dialog-content>
     <md-dialog-actions layout="row"> <span flex></span>
       <md-button ng-click="close()">Close</md-button>

--- a/private/tmpl/preview.tmpl.html
+++ b/private/tmpl/preview.tmpl.html
@@ -1,0 +1,21 @@
+<md-dialog aria-label="preview checklist" ng-cloak>
+  <form>
+    <md-toolbar>
+      <div class="md-toolbar-tools">
+        <h2>Preview Checklist</h2>
+      </div>
+    </md-toolbar>
+    <md-dialog-content>
+      <p>Preview Checklist "{{ checklist.checklistName }}"</p>
+      <ul>
+        <li ng-repeat="item in sortedItems">
+          {{ item.displayName }}
+        </li>
+      </ul>
+    </md-dialog-content>
+    <md-dialog-actions layout="row"> <span flex></span>
+      <md-button ng-click="close()">Close</md-button>
+      <md-button ng-click="assign()" style="margin-right:20px;">Assign To Me</md-button>
+    </md-dialog-actions>
+  </form>
+</md-dialog>

--- a/private/tmpl/preview.tmpl.html
+++ b/private/tmpl/preview.tmpl.html
@@ -17,7 +17,7 @@
     </md-dialog-content>
     <md-dialog-actions layout="row"> <span flex></span>
       <md-button ng-click="close()">Close</md-button>
-      <md-button ng-click="assign()" style="margin-right:20px;">Assign To Me</md-button>
+      <md-button ng-click="showAssignToMeDialog()" style="margin-right:20px;">Assign To Me</md-button>
     </md-dialog-actions>
   </form>
 </md-dialog>

--- a/spec/frontend/frontEndSpec.js
+++ b/spec/frontend/frontEndSpec.js
@@ -40,6 +40,7 @@ describe('todoCtrl', function () {
         course3: {
           prompt: 'Is it hosted on cloud.gov?',
           displayType: 'radio',
+          selected: 'Yes, it is.',
           possibleResponses: [{
             text: 'Yes, it is.',
             items: {
@@ -64,6 +65,38 @@ describe('todoCtrl', function () {
               }
             }
           }]
+        },
+        course4: {
+          prompt: 'What topics does this cover?',
+          displayType: 'checkbox',
+          possibleResponses: [
+            {
+              text: 'Technology',
+              selected: true,
+              items: {
+                Andrew: {
+                  displayName: 'Approver: Andrew',
+                  daysToComplete: 2,
+                  dependsOn: ['dayZero']
+                },
+                Tony: {
+                  displayName: 'Approver: Tony',
+                  daysToComplete: 2,
+                  dependsOn: ['Andrew']
+                }
+              }
+            },
+            {
+              text: 'Recruiting',
+              items: {
+                Jen: {
+                  displayName: 'Approver: Kaitlin',
+                  daysToComplete: 2,
+                  dependsOn: ['dayZero']
+                }
+              }
+            }
+          ]
         },
         finale: {
           displayName: 'The Finale',

--- a/spec/frontend/frontEndSpec.js
+++ b/spec/frontend/frontEndSpec.js
@@ -319,6 +319,53 @@ describe('AssignDialogController', function () {
   });
 });
 
+describe('PreviewChecklistController', function () {
+  var showDialog = function() {};
+
+  beforeEach(module('app'));
+
+  beforeEach(inject(function ($injector) {
+    var $controller = $injector.get('$controller');
+
+    var $mdDialog = {
+      cancel: function () {},
+      hide: function () {}
+    };
+
+    $rootScope = $injector.get('$rootScope');
+
+    createController = function () {
+      return $controller('PreviewChecklistController', {
+        $scope: $rootScope,
+        $mdDialog: $mdDialog,
+        checklist: {
+          checklistName: 'checklistName',
+          items: [
+            { displayName: 'display name' }
+          ]
+        },
+        showAssignToMeDialog: showDialog
+      });
+    };
+  }));
+
+  it('previews the checklist', function () {
+    createController();
+    expect($rootScope.checklist.checklistName).toEqual('checklistName');
+    expect($rootScope.checklist.items[0].displayName).toEqual('display name');
+  });
+
+  it('closes the dialog', function () {
+    createController();
+    $rootScope.close();
+  });
+
+  it('shows the assign dialog', function () {
+    createController();
+    $rootScope.showAssignToMeDialog();
+  });
+});
+
 describe('AddUserDialogController', function () {
   beforeEach(module('app'));
 

--- a/spec/frontend/frontEndSpec.js
+++ b/spec/frontend/frontEndSpec.js
@@ -320,7 +320,7 @@ describe('AssignDialogController', function () {
 });
 
 describe('PreviewChecklistController', function () {
-  var showDialog = function() {};
+  var showDialog = function () {};
 
   beforeEach(module('app'));
 

--- a/spec/frontend/frontEndSpec.js
+++ b/spec/frontend/frontEndSpec.js
@@ -191,6 +191,22 @@ describe('todoCtrl', function () {
     $httpBackend.flush();
   });
 
+  it('previews a checklist', function () {
+    var $mdDialog = {
+      hide: function () {},
+      show: function () {
+        return {
+          then: function (fn) {
+            fn(checklist);
+          }
+        };
+      }
+    };
+
+    createController($mdDialog);
+    $rootScope.showPreviewDialog(null, checklist);
+  });
+
   it('adds a new user', function () {
     var username = 'testUser';
     var $mdDialog = {


### PR DESCRIPTION
Ready for review. Ref #44 

Adds a "Preview" button to the checklist cards so that interested users can see the task names of the selected checklist. The tasks are displayed by `displayName`, and simply sorted by `daysToComplete` instead of going through the dependency tree to figure out exact ordering. The preview dialog includes an "Assign to Me" button to launch the Assign to Me dialog when clicked.

Also made a minor adjustment to the checklist card layout so that the card size flexes to full width on `xs` (< 600px) screen sizes.

<img width="538" alt="screen shot 2016-06-06 at 10 29 38 am" src="https://cloud.githubusercontent.com/assets/697848/15827790/4544cb88-2bd2-11e6-99f9-b46e19bea813.png">

cc @anthonygarvan 