### PR TITLE
add check for required environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ export SESSION_SECRET=testSessionSecret
 
 In production, make sure to set `SESSION_SECRET` to a long random string.
 
+You will also need to set `GITHUB_CALLBACK_URL` to the correct callback url for your domain. Its value should be of the form `https://<your-domain>.com/auth/callback`.
+
 If you'd like to customize the look a little, you may specify a logo path and a header color (as a valid HTML hex code or color name) as environment variables as well, otherwise 18F brand defaults will be used:
 ```shell
 export BRAND_LOGO_PATH=/private/img/18F-Logo-M.png

--- a/app.js
+++ b/app.js
@@ -23,7 +23,7 @@ var requiredEnv = ['GITHUB_CLIENT_ID', 'GITHUB_CLIENT_SECRET',
 
 requiredEnv.forEach(function (name) {
   if (!process.env[name]) {
-    throw new Error('Missing required environmental variable: ' + name);
+    throw new Error('Missing required environment variable: ' + name);
   }
 });
 

--- a/app.js
+++ b/app.js
@@ -18,6 +18,16 @@ var server;
 var app = express();
 var port = process.env.PORT || 3000;
 
+var requiredEnv = ['GITHUB_CLIENT_ID', 'GITHUB_CLIENT_SECRET',
+  'GITHUB_ORG', 'SESSION_SECRET'];
+
+requiredEnv.forEach(function (name) {
+  if (!process.env[name]) {
+    throw new Error('Missing required environmental variable: ' + name);
+  }
+});
+
+
 passport.serializeUser(function (user, done) {
   done(null, user);
 });


### PR DESCRIPTION
This change will cause the app to throw an error on start if a required environment variable is missing, which should prevent problems like the one we had today where the production app did not have `GITHUB_ORG` specified.