### PR TITLE
Use airbnb-base eslint config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+coverage
+node_modules
+bower_components

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 // Use this file as a starting point for your project's .eslintrc.
 // Copy this file, and add rule overrides as needed.
 {
-  "extends": "airbnb/legacy",
+  "extends": "airbnb-base/legacy",
   "rules": {
     "func-names": 0,
     "no-param-reassign": [2, { "props": false }],

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Run tests with:
 npm test
 ```
 
+Run eslint either via a code editor plugin (such as Atom's [linter-eslint](https://github.com/AtomLinter/linter-eslint)),
+or from the command line with:
+```shell
+npm run eslint
+```
+
 ## Deployment
 For 18Fers: this is deployed on cloud.gov. Get started on cloud.gov by following the instructions [here](https://docs.cloud.gov/). Ask for more details in the #checklistomania channel in slack.
 

--- a/api/api.js
+++ b/api/api.js
@@ -159,14 +159,14 @@ router.post('/assign-checklist', function (req, res) {
       var estimatedDueDate = new Date();
       var childItem = checklist.items[childItemId];
       estimatedDueDate.setTime(item.estimatedDueDate.getTime()
-        + childItem.daysToComplete * 24 * 60 * 60 * 1000 + 1
+        + (childItem.daysToComplete * 24 * 60 * 60 * 1000) + 1
       );
       checklist.items[childItemId].estimatedDueDate = estimatedDueDate;
     });
 
     if (item.dependsOn.indexOf('dayZero') >= 0) {
       dueDate = new Date();
-      dueDate.setTime(dayZeroDate.getTime() + item.daysToComplete * 24 * 60 * 60 * 1000 + 1);
+      dueDate.setTime(dayZeroDate.getTime() + (item.daysToComplete * 24 * 60 * 60 * 1000) + 1);
       item.dueDate = dueDate;
     }
     items.insert(item);

--- a/package.json
+++ b/package.json
@@ -23,11 +23,9 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.6",
-    "eslint": "^2.9.0",
-    "eslint-config-airbnb": "^9.0.1",
-    "eslint-plugin-import": "^1.7.0",
-    "eslint-plugin-jsx-a11y": "^1.2.0",
-    "eslint-plugin-react": "^5.1.1",
+    "eslint": "^3.1.0",
+    "eslint-config-airbnb-base": "^4.0.2",
+    "eslint-plugin-import": "^1.10.3",
     "istanbul": "^0.4.1",
     "jasmine-core": "^2.4.1",
     "jasmine-node": "^1.14.5",
@@ -51,6 +49,7 @@
     "test": "npm run backEndTests && npm run frontEndTests",
     "start": "node app.js",
     "dev-start": "nodemon app.js",
+    "eslint": "eslint . || true",
     "coverage": "istanbul cover node_modules/jasmine-node/bin/jasmine-node spec/backend",
     "coveralls": "cat ./coverage/lcov.info ./coverage/phantomjs/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
@@ -62,5 +61,5 @@
   "contributors": [
     "James Seppi <james.seppi@gsa.gov>"
   ],
-  "license": "CC0"
+  "license": "CC0-1.0"
 }

--- a/scripts/addEstimatedDueDate.js
+++ b/scripts/addEstimatedDueDate.js
@@ -1,35 +1,38 @@
 var MongoClient = require('mongodb').MongoClient;
 
 var url;
-if(process.env.VCAP_SERVICES) {
+var vcapServices;
+
+if (process.env.VCAP_SERVICES) {
   vcapServices = JSON.parse(process.env.VCAP_SERVICES);
-  url = vcapServices["mongodb26-swarm"][0].credentials.uri
+  url = vcapServices['mongodb26-swarm'][0].credentials.uri;
 } else {
   url = 'mongodb://localhost:27017/checklistomania';
 }
 
-MongoClient.connect(url, function(err, db) {
-  items = db.collection("items");
-  users = db.collection("users");
-  setTimeout(function() {db.close();}, 8000);
+MongoClient.connect(url, function (err, db) {
+  var items = db.collection('items');
+  var users = db.collection('users');
+  setTimeout(function () { db.close(); }, 8000);
 
   // clear all item estimated due date
-  items.find({}).toArray(function(err, userItems) {
-    userItems.forEach(function(item) {
+  items.find({}).toArray(function (itemFindErr, userItems) {
+    userItems.forEach(function (item) {
       delete item.estimatedDueDate;
-      items.update({_id: item._id}, item);
-    })
+      items.update({ _id: item._id }, item);
+    });
   });
 
-  users.find({}).toArray(function(err, userList) {
-    userList.forEach(function(user, userIdx) {
-      console.log('processing ' + user.username);
-      items.find({owner: user.username}).toArray(function(err, userItems) {
-        if(userItems.length > 0) {
-          userItems.forEach(function(item) {
+  users.find({}).toArray(function (userFindErr, userList) {
+    userList.forEach(function (user) {
+      console.log('processing ' + user.username); // eslint-disable-line no-console
+      items.find({ owner: user.username }).toArray(function (itemFindErr, userItems) {
+        if (userItems.length > 0) {
+          userItems.forEach(function (item) {
             item.estimatedDueDate = item.dueDate || new Date(2020, 1, 1);
-            items.update({"_id": item._id}, item);
-          })}
+            items.update({ _id: item._id }, item);
+          });
+        }
       });
     });
   });


### PR DESCRIPTION
- Use `airbnb-base/legacy` config for eslint, which removes the need for the react-specific eslint packages that aren't applicable to this project.
- Add an npm command to run eslint: `npm run eslint`.
- Bring a couple files up to linting standards.

Closes #89 