### PR TITLE
add Docker for easy dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,16 @@ RUN \
   mv /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/ /srv/var/phantomjs && \
   ln -s /srv/var/phantomjs/bin/phantomjs /usr/bin/phantomjs
 
-COPY package.json /checklistomania/
-
-WORKDIR /checklistomania
-
 RUN npm install -g bower
+
+# Based on guidance at http://jdlm.info/articles/2016/03/06/lessons-building-node-app-docker.html
+RUN useradd --user-group --create-home app
+
+ENV HOME=/home/app
+
+COPY package.json bower.json $HOME/checklistomania/
+RUN chown -R app:app $HOME/*
+
+USER app
+WORKDIR $HOME/checklistomania
 RUN npm install
-
-COPY . /checklistomania/
-
-# TODO: check if this works or what
-# RUN bower install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:5
+
+ENV PHANTOMJS_VERSION 1.9.7
+
+# https://hub.docker.com/r/cmfatih/phantomjs/~/dockerfile/
+RUN \
+  mkdir -p /srv/var && \
+  wget -q --no-check-certificate -O /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 && \
+  tar -xjf /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C /tmp && \
+  rm -f /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 && \
+  mv /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/ /srv/var/phantomjs && \
+  ln -s /srv/var/phantomjs/bin/phantomjs /usr/bin/phantomjs
+
+COPY package.json /checklistomania/
+
+WORKDIR /checklistomania
+
+RUN npm install -g bower
+RUN npm install
+
+COPY . /checklistomania/
+
+# TODO: check if this works or what
+# RUN bower install

--- a/README.md
+++ b/README.md
@@ -42,21 +42,21 @@ docker-compose up
 ```
 
 This will start up all required services in containers and output their
-log information to stdout. You should be able to visit http://localhost:3000/
-directly to access the site.
+log information to stdout. You should be able to visit
+[http://localhost:3000/](http://localhost:3000/) to view the site.
 
 To run any arbitrary command in the context of the application container, run:
 ```shell
 docker-compose run app <THE COMMAND>
 ```
 
-In the app container, `/checklistomania` is mapped to your host
-machine's checklistomania directory.
-
 For example, to run bash in the app container, run:
 ```shell
 docker-compose run app bash
 ```
+
+In the app container, `/checklistomania` is mapped to your host
+machine's checklistomania directory.
 
 To run a command in the mongo container, run:
 ```shell

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For example, to run bash in the app container, run:
 docker-compose run app bash
 ```
 
-In the app container, `/checklistomania` is mapped to your host
+In the app container, `/home/app/checklistomania` is mapped to your host
 machine's checklistomania directory.
 
 To run a command in the mongo container, run:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,55 @@ The users tab is where you can view the status of other team members action item
 ## Running Checklistomania
 Checklistomania is a [Node.js](https://nodejs.org) application on the back-end, and its front-end is an [AngularJS](https://angularjs.org/) single-page application.
 
-If you'd like to run Checklistomania for development purposes, follow these steps:
+### Using Docker for Development
+
+A Docker setup potentially makes development and deployment easier.
+
+To use it, install [Docker][] and [Docker Compose][] and read the
+[18F Docker guide][] if you haven't already.
+
+Then build the Docker images with:
+
+```sh
+docker-compose build
+```
+
+Once the above command finishes, run:
+
+```sh
+docker-compose up
+```
+
+This will start up all required services in containers and output their
+log information to stdout. You should be able to visit http://localhost:3000/
+directly to access the site.
+
+To run any arbitrary command in the context of the application container, run:
+```shell
+docker-compose run app <THE COMMAND>
+```
+
+In the app container, `/checklistomania` is mapped to your host
+machine's checklistomania directory.
+
+For example, to run bash in the app container, run:
+```shell
+docker-compose run app bash
+```
+
+To run a command in the mongo container, run:
+```shell
+docker-compose run mongo <THE COMMAND>
+```
+
+To remove all Docker images associated with this project, run
+```shell
+docker-compose down -v
+```
+
+### Running Locally
+
+If you'd like to run Checklistomania locally, follow these steps:
 
 First, install Node.js ([Download page](https://nodejs.org/en/download/)) and MongoDB ([Installation instructions](https://docs.mongodb.com/manual/installation/)). Make sure you have the same version of Node.js as specified in `package.json`.
 
@@ -74,13 +122,23 @@ Visit [http://localhost:3000/](http://localhost:3000/) to see the locally runnin
 ## Testing
 Make sure you have the same version of Node.js as specified in `package.json`, otherwise you may have trouble running the front end tests.
 
-Run tests with:
+If you are using Docker for development, run:
+```shell
+docker-compose run app npm test
+```
+
+If you are running Checklistomania locally, run:
 ```shell
 npm test
 ```
 
 Run eslint either via a code editor plugin (such as Atom's [linter-eslint](https://github.com/AtomLinter/linter-eslint)),
-or from the command line with:
+or from the command line. If you are using Docker, run:
+```shell
+docker-compose run app npm run eslint
+```
+
+If you are running locally, run:
 ```shell
 npm run eslint
 ```
@@ -94,3 +152,7 @@ This project is in the worldwide [public domain](LICENSE.md). As stated in [CONT
 > This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 >
 > All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
+
+[18F Docker guide]: https://pages.18f.gov/dev-environment-standardization/virtualization/docker/
+[Docker]: https://www.docker.com/
+[Docker Compose]: https://docs.docker.com/compose/

--- a/api/api.js
+++ b/api/api.js
@@ -45,7 +45,7 @@ if (process.env.VCAP_SERVICES) {
   vcapServices = JSON.parse(process.env.VCAP_SERVICES);
   url = vcapServices['mongodb26-swarm'][0].credentials.uri;
 } else {
-  url = 'mongodb://localhost:27017/checklistomania';
+  url = process.env.MONGODB_URI || 'mongodb://localhost:27017/checklistomania';
 }
 
 MongoClient.connect(url, function (connectErr, db) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 app:
   build: .
   volumes:
-    - .:/checklistomania
-    # http://stackoverflow.com/a/37898591
-    - /checklistomania/node_modules
+    - .:/home/app/checklistomania
+    # link node_modules to nothing on the host
+    - /home/app/checklistomania/node_modules
   links:
     - mongo
   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+app:
+  build: .
+  volumes:
+    - .:/checklistomania
+    # http://stackoverflow.com/a/37898591
+    - /checklistomania/node_modules
+  links:
+    - mongo
+  environment:
+    - GITHUB_CLIENT_ID=0a363c03ec2646619f57
+    - GITHUB_CLIENT_SECRET=01408892458c92e3514cd96cd6b31e6d91df25d2
+    - GITHUB_ORG=18F
+    - SESSION_SECRET=testSessionSecret
+    - MONGODB_URI=mongodb://mongo:27017/checklistomania
+  command: npm run dev-start
+  ports:
+    - "3000:3000"
+mongo:
+  image: mongo:3.2
+  environment:
+    - POSTGRES_DB=calc
+    - POSTGRES_USER=calc_user
+  ports:
+    - "27017:27017"


### PR DESCRIPTION
This PR adds necessary files for running Checklistomania via docker/docker-compose. It makes setting up a local dev version of the app much simpler since just two commands are needed to get up and running: `docker-compose build` and `docker-compose up`. Devs will no longer need to install mongo locally or setup env vars.

closes #99

Please review when you get a chance, @anthonygarvan 

Much of this is based on work by @toolness in other projects.