### PR TITLE
Remove reference to intake meeting

### DIFF
--- a/checklists/buddy.json
+++ b/checklists/buddy.json
@@ -67,11 +67,5 @@
 		"description": "See <a href=\"https://handbook.18f.gov/google-calendar\">Calendars</a> and <a href=\"https://handbook.18f.gov/general-contacts-and-listservs/#listservs\">Listservs</a>",
 		"daysToComplete": 4, 
 		"dependsOn": ["dayZero"]
-	},
-	"licenses": { 
-		"displayName": "Invite them to the Intake meeting",
-		"description": "Meetings take place every other Thursday at 12 EST", 
-		"daysToComplete": 30, 
-		"dependsOn": ["dayZero"]
 	}}
 }


### PR DESCRIPTION
Once upon a time, we had a weekly project intake meeting. We no longer do.

(This raises a larger question about how we orient newcomers to the staffing and resourcing process. That's arguably out of scope for this PR, but suggestions are welcome.)