### PR TITLE
Test structure of checklist JSONs

### DIFF
--- a/spec/backend/checklistSpec.js
+++ b/spec/backend/checklistSpec.js
@@ -1,0 +1,26 @@
+/* global describe:false it:false expect:false */
+var fs = require('fs');
+var path = require('path');
+
+var checklistsDir = path.join('checklists');
+
+describe('checklists are valid', function () {
+  it('all have a "dayZero" item', function (done) {
+    fs.readdir(checklistsDir, function (err, files) {
+      files.forEach(function (file) {
+        var chklist = JSON.parse(
+          fs.readFileSync(path.join(checklistsDir, file), 'utf8')
+        );
+        expect(chklist.checklistName).toBeDefined();
+        expect(chklist.checklistDescription).toBeDefined();
+        expect(chklist.items).toBeDefined();
+        expect(chklist.items instanceof Object).toBeTruthy();
+        expect(chklist.items.dayZero).toBeDefined();
+        expect(chklist.items.dayZero.daysToComplete).toBe(0);
+        expect(chklist.items.dayZero.dependsOn instanceof Array).toBeTruthy();
+        expect(chklist.items.dayZero.dependsOn.length).toBe(0);
+      });
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a test to do some validation of all of the checklist JSON files, ref https://github.com/18F/checklistomania/issues/123. It should help catch issues such as the one documented in https://github.com/18F/checklistomania/issues/121#issuecomment-259762490 (a missing `"dayZero"` item).

A more complete solution would probably be to use http://json-schema.org/, but I don't have time to implement that right now. Maybe we could just create another "help wanted" issue for that?

Thoughts, @anthonygarvan?