### PR TITLE
Test that item dependencies actually exist

### DIFF
--- a/spec/backend/checklistSpec.js
+++ b/spec/backend/checklistSpec.js
@@ -4,21 +4,54 @@ var path = require('path');
 
 var checklistsDir = path.join('checklists');
 
-describe('checklists are valid', function () {
-  it('all have a "dayZero" item', function (done) {
-    fs.readdir(checklistsDir, function (err, files) {
-      files.forEach(function (file) {
-        var chklist = JSON.parse(
-          fs.readFileSync(path.join(checklistsDir, file), 'utf8')
-        );
-        expect(chklist.checklistName).toBeDefined();
-        expect(chklist.checklistDescription).toBeDefined();
-        expect(chklist.items).toBeDefined();
-        expect(chklist.items instanceof Object).toBeTruthy();
-        expect(chklist.items.dayZero).toBeDefined();
-        expect(chklist.items.dayZero.daysToComplete).toBe(0);
-        expect(chklist.items.dayZero.dependsOn instanceof Array).toBeTruthy();
-        expect(chklist.items.dayZero.dependsOn.length).toBe(0);
+function forEachChecklist(fn) {
+  fs.readdir(checklistsDir, function (err, files) {
+    files.forEach(function (file) {
+      var chklist = JSON.parse(
+        fs.readFileSync(path.join(checklistsDir, file), 'utf8')
+      );
+      fn(chklist, file);
+    });
+  });
+}
+
+
+forEachChecklist(function (chklist, file) {
+  describe('Valid ' + file, function () {
+    it('has a "dayZero" item', function (done) {
+      expect(chklist.checklistName).toBeDefined();
+      expect(chklist.checklistDescription).toBeDefined();
+      expect(chklist.items).toBeDefined();
+      expect(chklist.items instanceof Object).toBeTruthy();
+      expect(chklist.items.dayZero).toBeDefined();
+      expect(chklist.items.dayZero.daysToComplete).toBe(0);
+      expect(chklist.items.dayZero.dependsOn instanceof Array).toBeTruthy();
+      expect(chklist.items.dayZero.dependsOn.length).toBe(0);
+      done();
+    });
+
+    it('has dependencies that exist', function (done) {
+      var itemNames = Object.keys(chklist.items);
+      itemNames.forEach(function (name) {
+        var item = chklist.items[name];
+        if (item.prompt) {
+          item.possibleResponses.forEach(function (response) {
+            var responseItemNames = Object.keys(response.items);
+            responseItemNames.forEach(function (responseItemName) {
+              var responseItem = response.items[responseItemName];
+              responseItem.dependsOn.forEach(function (dependency) {
+                expect([].concat(itemNames).concat(responseItemNames))
+                  .toContain(dependency);
+              });
+            });
+          });
+        }
+        if (item.dependsOn) {
+          expect(item.dependsOn instanceof Array).toBeTruthy();
+          item.dependsOn.forEach(function (dependency) {
+            expect(itemNames).toContain(dependency);
+          });
+        }
       });
       done();
     });


### PR DESCRIPTION
Add another checklist file test to make sure all the item names in `dependsOn` actually exist in the checklist.

This PR also includes a light refactoring of the checklist spec to create a new `describe` block per checklist file. This has the benefit of producing better output when one of the tests fails, since it will output exactly which file has the problem.

Closes #134